### PR TITLE
Add Task Sheet Functions

### DIFF
--- a/contract/main_task/Move.lock
+++ b/contract/main_task/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 2
-manifest_digest = "C802C046FC86739CBFF503CA0A821A8B81B79017082C378BA623E58DCF208148"
+manifest_digest = "BB4C1DBD012283B2660FDA97156F7169083B40D2EC8ED86750223B2CDEAC500B"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 dependencies = [
   { name = "Sui" },
@@ -29,6 +29,6 @@ flavor = "sui"
 
 [env.devnet]
 chain-id = "f4950f51"
-original-published-id = "0xab985c2ee7fb73b3fe7d362714f4c721cf56254d6b2cbca2ad440ef7202033a9"
-latest-published-id = "0xab985c2ee7fb73b3fe7d362714f4c721cf56254d6b2cbca2ad440ef7202033a9"
+original-published-id = "0xcb5cb7e5284bfbb2ae3fb7b089e87e9c1b3b2e38cc03eea759537a5da3b483a5"
+latest-published-id = "0xcb5cb7e5284bfbb2ae3fb7b089e87e9c1b3b2e38cc03eea759537a5da3b483a5"
 published-version = "1"

--- a/contract/main_task/Move.lock
+++ b/contract/main_task/Move.lock
@@ -29,6 +29,6 @@ flavor = "sui"
 
 [env.devnet]
 chain-id = "f4950f51"
-original-published-id = "0xb5d4fa6767ed48943be2c2c058de48d167afc8813a9ba38e6ca4506ec70c6cc1"
-latest-published-id = "0xb5d4fa6767ed48943be2c2c058de48d167afc8813a9ba38e6ca4506ec70c6cc1"
+original-published-id = "0xab985c2ee7fb73b3fe7d362714f4c721cf56254d6b2cbca2ad440ef7202033a9"
+latest-published-id = "0xab985c2ee7fb73b3fe7d362714f4c721cf56254d6b2cbca2ad440ef7202033a9"
 published-version = "1"

--- a/contract/main_task/Move.lock
+++ b/contract/main_task/Move.lock
@@ -29,6 +29,6 @@ flavor = "sui"
 
 [env.devnet]
 chain-id = "f4950f51"
-original-published-id = "0xcb5cb7e5284bfbb2ae3fb7b089e87e9c1b3b2e38cc03eea759537a5da3b483a5"
-latest-published-id = "0xcb5cb7e5284bfbb2ae3fb7b089e87e9c1b3b2e38cc03eea759537a5da3b483a5"
+original-published-id = "0xb225cfce9decbc9af3bd6a472f71bf9ad5ee2d66cfa7a873d7c59f68d617b5db"
+latest-published-id = "0xb225cfce9decbc9af3bd6a472f71bf9ad5ee2d66cfa7a873d7c59f68d617b5db"
 published-version = "1"

--- a/contract/main_task/Move.toml
+++ b/contract/main_task/Move.toml
@@ -20,6 +20,7 @@ Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-fram
 
 [addresses]
 main_task = "0x0"
+EYES = "0x9ef7b63e4e94a4d4ca517707f6bf7e063250c2dc6ee0ac855cf208abc415d30a"
 
 # Named addresses will be accessible in Move as `@name`. They're also exported:
 # for example, `std = "0x1"` is exported by the Standard Library.

--- a/contract/main_task/sources/main_task.move
+++ b/contract/main_task/sources/main_task.move
@@ -4,7 +4,7 @@ module main_task::main_task {
     // Dependencies
 
     use std::string::{ String };
-    // use std::vector::{ length, borrow_mut };
+    use std::vector::{ length, borrow };
     use sui::clock::{ Self, Clock };
     use main_task::task_description::{create_task_description, TaskDescription};
     use sui::coin::{Self, Coin};
@@ -193,15 +193,13 @@ module main_task::main_task {
         task.moderator
     }
 
-    /*
-    public(package) fun get_task_description<T> (
-        task: &mut Task<T>,
-    ): TaskDescription {
-        let i = length(task.description);
-        borrow_mut(task.description, i)
-    }
-    */
     
+    public(package) fun get_task_description<T> (
+        task: &Task<T>,
+    ): TaskDescription {
+        let i = length(&task.description) - 1;
+        *borrow(&task.description, i)
+    }
     
 
 }

--- a/contract/main_task/sources/main_task.move
+++ b/contract/main_task/sources/main_task.move
@@ -3,7 +3,8 @@ module main_task::main_task {
 
     // Dependencies
 
-    use std::string::{ String};
+    use std::string::{ String };
+    // use std::vector::{ length, borrow_mut };
     use sui::clock::{ Self, Clock };
     use main_task::task_description::{create_task_description, TaskDescription};
     use sui::coin::{Self, Coin};
@@ -179,6 +180,27 @@ module main_task::main_task {
     ): u64 {
         task.reward_amount
     }
+
+    public(package) fun get_task_id<T>(
+        task: &Task<T>,
+    ): ID {
+        object::uid_to_inner(&task.id)
+    }
+
+    public(package) fun get_task_mod<T>(
+        task: &Task<T>,
+    ): address {
+        task.moderator
+    }
+
+    /*
+    public(package) fun get_task_description<T> (
+        task: &mut Task<T>,
+    ): TaskDescription {
+        let i = length(task.description);
+        borrow_mut(task.description, i)
+    }
+    */
     
     
 

--- a/contract/main_task/sources/main_task.move
+++ b/contract/main_task/sources/main_task.move
@@ -71,7 +71,7 @@ module main_task::main_task {
         // create the main task object 
         let task = Task<T>{
             id: object::new(ctx),
-            version: 1,
+            version: 1u8,
             name,
             description: description_vector,
             image_url,

--- a/contract/main_task/sources/task_record.move
+++ b/contract/main_task/sources/task_record.move
@@ -4,8 +4,8 @@ module main_task::task_record {
 
     use std::string::String;
     use sui::clock::{ Self, Clock };
-    use main_task::main_task::{ Task, get_task_id, get_task_mod };
-
+    use main_task::main_task::{ Task, get_task_id, get_task_mod, get_task_description };
+    use main_task::task_description::{ TaskDescription };
 
     // Task AdminCap
 
@@ -19,8 +19,8 @@ module main_task::task_record {
     public struct TaskSheet has key, store {
         id: UID,
         main_task_id: ID,
-        // TODO: add default task content
-        content: String,
+        task_description: TaskDescription,
+        content: Option<String>,
         receipient: address,
         creator: address,
         created_time: u64,
@@ -30,21 +30,21 @@ module main_task::task_record {
     // Mint Task Sheet By Tasker
 
     public entry fun mint_task_sheet<T>(
-        content: String,
         main_task: &mut Task<T>,
         date: &Clock,
         ctx: &mut TxContext
     ){
         let id = object::new(ctx);
         let main_task_id = get_task_id(main_task);
+        let task_description = get_task_description(main_task);
         let creator = ctx.sender();
         let receipient = get_task_mod(main_task);
 
         let task_sheet = TaskSheet {
             id,
             main_task_id,
-            // TODO: add default task content
-            content,
+            task_description,
+            content: option::none(),
             receipient,
             creator,
             created_time: clock::timestamp_ms(date),
@@ -72,7 +72,7 @@ module main_task::task_record {
         _: &TaskAdminCap
     ) {
         let update_time = clock::timestamp_ms(update_time);
-        task_sheet.content = content;
+        task_sheet.content = option::some(content);
         task_sheet.update_time = update_time
     }
 

--- a/contract/main_task/sources/task_record.move
+++ b/contract/main_task/sources/task_record.move
@@ -6,6 +6,14 @@ module main_task::task_record {
     use sui::clock::{ Self, Clock };
     use main_task::main_task::{ Task, get_task_id, get_task_mod };
 
+
+    // Task AdminCap
+
+    public struct TaskAdminCap has key, store {
+        id: UID,
+    }
+
+
     // TaskSheet
 
     public struct TaskSheet has key, store {
@@ -16,7 +24,7 @@ module main_task::task_record {
         receipient: address,
         creator: address,
         created_time: u64,
-        // TODO: add update-time
+        update_time: u64
     }
 
     // Mint Task Sheet By Tasker
@@ -39,13 +47,18 @@ module main_task::task_record {
             content,
             receipient,
             creator,
-            created_time: clock::timestamp_ms(date)
-            // TODO: add update-time
-            // TODO: admin_cap
+            created_time: clock::timestamp_ms(date),
+            update_time: clock::timestamp_ms(date)
         };
 
+        let task_admin_cap = TaskAdminCap { id: object::new(ctx) };
+
         // transfer task sheet to tasker
-        transfer::public_transfer(task_sheet, creator)
+        transfer::public_transfer(task_sheet, creator);
+
+
+        // transfer task admincap to tasker
+        transfer::public_transfer(task_admin_cap, creator)
 
     }
 
@@ -55,11 +68,12 @@ module main_task::task_record {
     public entry fun update_task_sheet_content (
         task_sheet: &mut TaskSheet,
         content: String,
-        update_time: &Clock
+        update_time: &Clock,
+        _: &TaskAdminCap
     ) {
         let update_time = clock::timestamp_ms(update_time);
         task_sheet.content = content;
-        task_sheet.created_time = update_time // TODO: change to  update-time
+        task_sheet.update_time = update_time
     }
 
 
@@ -67,6 +81,7 @@ module main_task::task_record {
 
     public entry fun submit_task_sheet (
         task_sheet: TaskSheet,
+        _: &TaskAdminCap
     ) {
         let receipient = task_sheet.receipient;
         transfer::public_transfer(task_sheet, receipient)

--- a/contract/main_task/sources/task_record.move
+++ b/contract/main_task/sources/task_record.move
@@ -56,7 +56,6 @@ module main_task::task_record {
         // transfer task sheet to tasker
         transfer::public_transfer(task_sheet, creator);
 
-
         // transfer task admincap to tasker
         transfer::public_transfer(task_admin_cap, creator)
 

--- a/contract/main_task/sources/task_record.move
+++ b/contract/main_task/sources/task_record.move
@@ -1,0 +1,76 @@
+module main_task::task_record {
+
+    // Dependencies
+
+    use std::string::String;
+    use sui::clock::{ Self, Clock };
+    use main_task::main_task::{ Task, get_task_id, get_task_mod };
+
+    // TaskSheet
+
+    public struct TaskSheet has key, store {
+        id: UID,
+        main_task_id: ID,
+        // TODO: add default task content
+        content: String,
+        receipient: address,
+        creator: address,
+        created_time: u64,
+        // TODO: add update-time
+    }
+
+    // Mint Task Sheet By Tasker
+
+    public entry fun mint_task_sheet<T>(
+        content: String,
+        main_task: &mut Task<T>,
+        date: &Clock,
+        ctx: &mut TxContext
+    ){
+        let id = object::new(ctx);
+        let main_task_id = get_task_id(main_task);
+        let creator = ctx.sender();
+        let receipient = get_task_mod(main_task);
+
+        let task_sheet = TaskSheet {
+            id,
+            main_task_id,
+            // TODO: add default task content
+            content,
+            receipient,
+            creator,
+            created_time: clock::timestamp_ms(date)
+            // TODO: add update-time
+            // TODO: admin_cap
+        };
+
+        // transfer task sheet to tasker
+        transfer::public_transfer(task_sheet, creator)
+
+    }
+
+
+    // Modify Content On Task Sheet
+
+    public entry fun update_task_sheet_content (
+        task_sheet: &mut TaskSheet,
+        content: String,
+        update_time: &Clock
+    ) {
+        let update_time = clock::timestamp_ms(update_time);
+        task_sheet.content = content;
+        task_sheet.created_time = update_time // TODO: change to  update-time
+    }
+
+
+    // Submit TaskSheet to Mod
+
+    public entry fun submit_task_sheet (
+        task_sheet: TaskSheet,
+    ) {
+        let receipient = task_sheet.receipient;
+        transfer::public_transfer(task_sheet, receipient)
+    }
+
+
+}

--- a/contract/main_task/sources/task_record.move
+++ b/contract/main_task/sources/task_record.move
@@ -18,6 +18,7 @@ module main_task::task_record {
 
     public struct TaskSheet has key, store {
         id: UID,
+        status: u8, // status field - 0: Not Submitted, 1: Pending Review, 2: Approved
         main_task_id: ID,
         task_description: TaskDescription,
         content: Option<String>,
@@ -35,6 +36,7 @@ module main_task::task_record {
         ctx: &mut TxContext
     ){
         let id = object::new(ctx);
+        let status = 0u8;
         let main_task_id = get_task_id(main_task);
         let task_description = get_task_description(main_task);
         let creator = ctx.sender();
@@ -42,6 +44,7 @@ module main_task::task_record {
 
         let task_sheet = TaskSheet {
             id,
+            status,
             main_task_id,
             task_description,
             content: option::none(),
@@ -79,12 +82,15 @@ module main_task::task_record {
     // Submit TaskSheet to Mod
 
     public entry fun submit_task_sheet (
-        task_sheet: TaskSheet,
+        mut task_sheet: TaskSheet,
+        date: &Clock,
         _: &TaskAdminCap
     ) {
+        task_sheet.update_time = clock::timestamp_ms(date);
+        task_sheet.status = 1u8;
+
         let receipient = task_sheet.receipient;
         transfer::public_transfer(task_sheet, receipient)
     }
-
 
 }


### PR DESCRIPTION
## New Features:
- Mint task sheet by tasker, with create_time and update_time and status and the original task descriptions.
- Tasker with the `task_admin_cap` was able to modify task sheet content and submit tasksheet to MOD (assigned by task owner.)